### PR TITLE
Fix sync block not being retrieved on start

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -35,7 +35,7 @@ const startCore = ({ chain, core, config: coreConfig }, store) => {
   emitter.on('open-wallets', ({ address }) => {
     // TODO request to rescan unconfirmed txs
     storage
-      .getSyncBlock()
+      .getSyncBlock(chain)
       .then(from => {
         emitter.emit('transactions-scan-started')
         return coreApi.explorer.syncTransactions(from, address)


### PR DESCRIPTION
This issue caused all transactions to be re-scanned from block 0 on wallet start.