### PR TITLE
Fix android build after google play services June 17, 2019 update

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -151,13 +151,19 @@ android {
 
 dependencies {
     compile project(':react-native-config')
-    compile project(':react-native-google-analytics-bridge')
+    implementation(project(":react-native-google-analytics-bridge"),  {
+        exclude group: "com.google.android.gms"
+    })
+    implementation "com.google.android.gms:play-services-analytics:16.0.8"
     compile project(':react-native-sentry')
     compile project(':react-native-version-number')
     compile project(':react-native-restart')
     compile project(':react-native-splash-screen')
     compile project(':react-native-keychain')
-    compile project(':react-native-camera')
+    implementation(project(":react-native-camera"),  {
+        exclude group: "com.google.android.gms"
+    })
+    implementation "com.google.android.gms:play-services-vision:16.2.0"
     compile project(':react-native-svg')
     compile project(':react-native-randombytes')
     compile fileTree(dir: "libs", include: ["*.jar"])


### PR DESCRIPTION
Some of the libraries we are using didn't have exact versions of Google Play Services, so after Google major release with breaking changes, the build started to fail.

This pull request forces our app to use exact versions before the upgrade.