### PR TITLE
Increase web3 calls timeout

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -42,5 +42,6 @@ export default {
   sentryDsn: Config.SENTRY_DSN,
   settingsVersion: 2,
   statePersistanceDebounce: 2000,
-  trackingId: Config.TRACKING_ID || ''
+  trackingId: Config.TRACKING_ID || '',
+  web3Timeout: 120000
 }


### PR DESCRIPTION
This will help preventing syncing transactions to fail if the nodes are not responsive enough.