### PR TITLE
Update fastfile to use the new bundler when publishing to play store

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,7 @@
 fastlane_version "2.118.1"
 begin
   setup_travis
-  xcversion(version: "10.1")
+  xcversion(version: "12.5")
 rescue
   puts "Could not create keychain and set Xcode version"
 end
@@ -51,7 +51,7 @@ platform :android do
   desc "Build the Android application."
   private_lane :build do
     gradle(task: "clean", project_dir: "android/")
-    gradle(task: "assemble", build_type: "Release", project_dir: "android/")
+    gradle(task: "bundle", build_type: "Release", project_dir: "android/")
   end
 
   desc "Ship to Playstore Beta."

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew cask install fastlane`
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ## iOS
@@ -38,6 +38,6 @@ Ship to Playstore Beta.
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
 The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
Closes #127   
Although the change is small, it required some research and testing

Now, running `npm run android:beta` will generate a `.aab` file which is an accepted new format by the play store

Effort: 0.5d